### PR TITLE
🔧 Ajusta importacao do accordion types e adiciona .vercel no git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.vercel

--- a/src/components/ui/accordiont.tsx
+++ b/src/components/ui/accordiont.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion'
-import type { AccordionProps } from '@/types/animation'
+import type { AccordionProps } from '@/types/accordions'
 import { ChevronRight } from 'lucide-react'
 
 export const Accordion = ({


### PR DESCRIPTION
## Descrição  
Esta PR faz ajustes na importacao do type do acordeao. As principais mudanças incluem:  

- 📝 **Atualização da importacao do arquivo** para seguir um padrão consistente.  
- 📖 **Adiciona .vercel no gitignore** para impertir que a pasta va para o git.  

## Motivação  
Essas mudanças corrige a falha no build da aplicacao e impede o git de ficar cheios de arquivos temporarios.  

## Testes  
- O projeto foi testado localmente após as alterações e os imports foram validados.  
- Nenhuma funcionalidade foi alterada, garantindo que o comportamento esperado seja mantido.  

## Checklist  
- [x] Ajustei o imports corretamente  
- [x] Adicionei .vercel no gitignore
