### PR TITLE
# 🔧 Remove state from useEffect deps

### DIFF
--- a/src/app/user-list/page.tsx
+++ b/src/app/user-list/page.tsx
@@ -71,7 +71,7 @@ export default function UserListPage() {
 
   useEffect(() => {
     fetchUsers()
-  }, [users])
+  }, [])
 
   return (
     <Suspense fallback={<Loading />}>


### PR DESCRIPTION
## Descrição  
Esta PR corrige um bug que faz a rela ficar em looping infinito na renderizacao do componente. As principais mudanças incluem:  

- 📝 **Remove o estado do array de dependencia** para parar com o looping.  

## Motivação  
Essa mudanca impede a aplicacao de ficar em looping e ter um consumo excessivo de processamento.

## Testes  
- O projeto foi testado localmente após as alterações e os imports foram validados.  
- Nenhuma funcionalidade foi alterada, garantindo que o comportamento esperado seja mantido.  

## Checklist  
- [x] Ajustei o array de dependencias do useEffect